### PR TITLE
Add Jest config and sample tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,13 @@
+export default {
+  preset: 'ts-jest/presets/default-esm',
+  testEnvironment: 'node',
+  extensionsToTreatAsEsm: ['.ts'],
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
+  globals: {
+    'ts-jest': {
+      useESM: true,
+    },
+  },
+};

--- a/src/api/main.test.ts
+++ b/src/api/main.test.ts
@@ -1,0 +1,14 @@
+import app from './main.js';
+import { AddressInfo } from 'net';
+
+describe('API endpoints', () => {
+  test('GET /healthz returns ok', async () => {
+    const server = app.listen(0);
+    const { port } = server.address() as AddressInfo;
+    const res = await fetch(`http://127.0.0.1:${port}/healthz`);
+    const body = await res.json();
+    server.close();
+    expect(res.status).toBe(200);
+    expect(body).toEqual({ status: 'ok' });
+  });
+});

--- a/src/api/main.ts
+++ b/src/api/main.ts
@@ -444,15 +444,17 @@ function generateCardUsageTips(matchingCards: any[]): Record<string, string> {
 }
 
 // Start the server
-initializeDatabase()
-  .then(() => {
-    app.listen(port, () => {
-      console.log(`⚡️[MCP Server]: Server is running at http://localhost:${port}`);
+if (process.env.NODE_ENV !== 'test') {
+  initializeDatabase()
+    .then(() => {
+      app.listen(port, () => {
+        console.log(`⚡️[MCP Server]: Server is running at http://localhost:${port}`);
+      });
+    })
+    .catch((error) => {
+      console.error('Failed to initialize database and start server:', error);
+      process.exit(1);
     });
-  })
-  .catch((error) => {
-    console.error('Failed to initialize database and start server:', error);
-    process.exit(1);
-  });
+}
 
 export default app; 

--- a/src/calc_savings.test.ts
+++ b/src/calc_savings.test.ts
@@ -1,0 +1,23 @@
+import * as duckdb from 'duckdb';
+import { calcTopN, SpendProfile } from './calc_savings.js';
+
+describe('calcTopN', () => {
+  test('returns top card based on rewards', async () => {
+    const db = new duckdb.Database(':memory:');
+    const conn = new duckdb.Connection(db);
+
+    conn.run(`
+      CREATE TABLE cards (id INTEGER, card_name VARCHAR, annual_fee DECIMAL);
+      CREATE TABLE category_caps (card_id INTEGER, category VARCHAR, reward_rate DECIMAL);
+    `);
+
+    conn.run(`INSERT INTO cards VALUES (1, 'Card A', 0), (2, 'Card B', 0);`);
+    conn.run(`INSERT INTO category_caps VALUES (1, 'amazon_spends', 0.02), (2, 'amazon_spends', 0.01);`);
+
+    const spend: SpendProfile = { amazon_spends: 1000 } as SpendProfile;
+    const results = await calcTopN(conn, spend, 1);
+
+    expect(results[0]).toMatchObject({ card_id: 1, card_name: 'Card A' });
+    expect(results[0].annual_total).toBeCloseTo(240);
+  });
+});

--- a/src/services/openai.test.ts
+++ b/src/services/openai.test.ts
@@ -1,0 +1,8 @@
+import { parseIntentAndSpends } from './openai.js';
+
+describe('parseIntentAndSpends', () => {
+  test('falls back to UNKNOWN when OpenAI is not configured', async () => {
+    const result = await parseIntentAndSpends('test message');
+    expect(result).toEqual({ intent: 'UNKNOWN', spend: {}, ambiguous: ['test message'] });
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest configuration for ts-jest
- ensure API server doesn't start during test runs
- add unit tests for calcTopN and parseIntentAndSpends
- add health check endpoint test

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683feac6e0e48320a23942535abbbb46